### PR TITLE
Fix Streaming Analytics Workshop link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ aws s3 sync ./regional-s3-assets s3://$ARTIFACT_BUCKET-us-east-1/$SOLUTION_NAME/
 - [Kinesis Producer Library](https://github.com/awslabs/amazon-kinesis-producer)
 - [Amazon Kinesis Data Analytics Java Examples](https://github.com/aws-samples/amazon-kinesis-data-analytics-java-examples)
 - [Flink: Hands-on Training](https://ci.apache.org/projects/flink/flink-docs-master/learn-flink/)
-- [Streaming Analytics Workshop](https://streaming-analytics.workshop.aws/en)
+- [Streaming Analytics Workshop](https://streaming-analytics.workshop.aws/flink-on-kda/)
 - [Kinesis Scaling Utility](https://github.com/awslabs/amazon-kinesis-scaling-utils)
 
 ***


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Link for the "Streaming Analytics Workshop" on the README file was broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
